### PR TITLE
Switch out @transition-ease-quick with @transition-duration-base

### DIFF
--- a/styles/leaflet-overrides.less
+++ b/styles/leaflet-overrides.less
@@ -96,7 +96,7 @@
 		border: @border-base;
 		border-radius: @border-radius-base;
 		border-bottom-width: 0;
-		.transition( ~'background-color @transition-ease-quick, color @transition-ease-quick, border-color @transition-ease-quick, box-shadow @transition-ease-quick' );
+		.transition( ~'background-color @transition-duration-base, color @transition-duration-base, border-color @transition-duration-base, box-shadow @transition-duration-base' );
 
 		&:hover {
 			background-color: @background-color-framed--hover;


### PR DESCRIPTION
The `@transition-ease-quick` LESS variable is not defined (anymore?) in the variables style sheet `/wikimedia-ui-base.less`. Switch with @transition-duration-base as used by other OOUI buttons and its like.