### PR TITLE
Make the help link variable via mw message

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -230,7 +230,8 @@
 				"modules/controls/style.css"
 			],
 			"messages": [
-				"kartographer-attribution"
+				"kartographer-attribution",
+				"kartographer-help-link"
 			],
 			"targets": [
 				"mobile",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -29,6 +29,7 @@
 	"kartographer-coord-lon-negative": "$1W",
 	"kartographer-coord-lat-decimal": "Y: $1",
 	"kartographer-coord-lon-decimal": "X: $1",
+	"kartographer-help-link": "https://oldschool.runescape.wiki/w/RuneScape:Map",
 	"kartographer-map-addinfo": "$2 (mapID: $1)<br />Zoom: $3  Plane: $4",
 	"kartographer-specialmap-note": "Url uses the format: Special:Map/''mapID''/''zoom''/''plane''/''x''/''y''",
 	"kartographer-specialmap-invalid-coordinates": "Invalid coordinates supplied",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -37,6 +37,7 @@
 	"kartographer-specialmap-invalid-coordinates": "Displayed by Special:Map when no valid coordinates are supplied",
 	"kartographer.css": "{{optional}}",
 	"kartographer.js": "{{optional}}",
+	"kartographer-help-link": "A link to the map help page (? help button on maps).",
 	"kartographer-linktype-aerial": "Appears on the sidebar of the full screen map. A plural adjective, as in \"aerial (maps)\".\n\n{{Identical|Aerial}}",
 	"kartographer-linktype-map": "Appears on the sidebar of the full screen map.",
 	"kartographer-linktype-other": "Appears on the sidebar of the full screen map. A plural adjective, as in \"Other (maps)\".\n\n{{Identical|Other}}",

--- a/modules/controls/Help.js
+++ b/modules/controls/Help.js
@@ -13,7 +13,7 @@ L.Control.extend( {
     buttonText: '<i class="fa fa-question">?</i>', // The text set on the 'options' button.
     buttonTitle: 'Help', // The title set on the 'options' button.
 
-    linkURL: 'https://oldschool.runescape.wiki/w/RuneScape:Map',
+    linkURL: mw.message( 'kartographer-help-link' ).plain(),
   },
 
   onAdd: function(map) {


### PR DESCRIPTION
Makes it possible to set the link target of the help button (top right in full screen) via a mediawiki message. So that rs3 wiki can link to itself instead of os.